### PR TITLE
Muutettu tietokantayhteys käyttämään .env tiedostoa

### DIFF
--- a/gamelab/src/server/Program.cs
+++ b/gamelab/src/server/Program.cs
@@ -1,5 +1,6 @@
 
 using System.Text.Json.Serialization;
+using DotNetEnv;
 using gamelab.Services;
 using gamelab.src.server;
 using gamelab.src.server.Services;
@@ -7,6 +8,9 @@ using Microsoft.EntityFrameworkCore;
 
 
 var builder = WebApplication.CreateBuilder(args);
+
+//Tuodaan ympäristömuuttujat käyttöön
+Env.Load();
 
 //Lisätään kontrollerit ja Json sterilisaatio ( enum -> string)
 builder.Services
@@ -16,8 +20,14 @@ builder.Services
         options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
     });
 
-//Luodaan yhteys tietokantaan
-var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+
+//Luodaan yhteys tietokantaan käyttäen ympäristömuuttujia
+var connectionString = $"Server={Env.GetString("DB_HOST")};" +
+                       $"Port={Env.GetString("DB_PORT")};" +
+                       $"Database={Env.GetString("DB_NAME")};" +
+                       $"Username={Env.GetString("DB_USER")};" +
+                       $"Password={Env.GetString("DB_PASS")}";
+
 builder.Services.AddDbContext<AppDbContext>(options => 
     options.UseNpgsql(connectionString));
     

--- a/gamelab/src/server/README.md
+++ b/gamelab/src/server/README.md
@@ -14,20 +14,16 @@
 - `AppDbContext.cs`: Luokka, joka vastaa tietokannan yhteydenpidosta.
 
 - `appsettings.json`: Sovelluksen asetuksia
-  HUOM! Tämä menee githubiin
+  
 
-- `appsettings.Development.json`: Kehitystilan asteuksia, mm. ConnectionString
-  HUOM! Tämä ei mene githubiin
+- `appsettings.Development.json`: Kehitystilan asteuksia.
 
 - `DataSeeder.cs` : Joka luo tietokantaan datan ( huoneen, tietokoneet ja testikäyttäjän)
 
   - `Program.cs`: Täältä käynnistetään sovellus ja määritellään asetuksia.
 
-# Kehitystyötä tehdessä
 
-Luotava appsettings.Developmnet.json tiedosto jonne
-
-## TODO Muutetaan toimimaan .env tiedostosta
+# Tietokantayhteyden parametrit haetaan .env tiedostosta
 
 # Asennetut NuGet paketit:
 

--- a/gamelab/src/server/appsettings.Development.json
+++ b/gamelab/src/server/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
     "ConnectionStrings": {
-      "DefaultConnection": "Server=localhost;Port=5432;Database=GameLab;Username=postgres;Password=password;"
+      "DefaultConnection": "Server=localhost;Port=5432;Database=GameLab;Username=postgres;Password=password"
     },
     "Logging": {
       "LogLevel": {

--- a/gamelab/src/server/appsettings.json
+++ b/gamelab/src/server/appsettings.json
@@ -1,6 +1,6 @@
 {
 "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost;Database=GameLab;Username=postgres;Password=0000;"
+    "DefaultConnection": "Server=localhost;Database=GameLab;Username=postgres;Password=password"
   },
 
   "Logging": {


### PR DESCRIPTION
Tietokantayhteys muodostetaan nyt program.cs tiedostostosta, appsettings ja appsettingsDevelopment tiedostojen sijasta. 
Laitan Discordiin .env tiedoston rakenteen.