### PR TITLE
Gs 11 käyttäjätietojen tallennus tietokantaan

### DIFF
--- a/gamelab/src/server/Controllers/UserController.cs
+++ b/gamelab/src/server/Controllers/UserController.cs
@@ -114,6 +114,44 @@ namespace gamelab.src.server.Controllers
             }
         }
 
+        /// HTTP POST -metodi uuden käyttäjän luonnille
+        /// Vastaanottaa käyttäjänimen ja sähköpostin, generoi kertakäyttökoodin ja tallentaa tiedot tietokantaan
+        /// <param name="dto">Uuden käyttäjän tiedot</param>
+        [HttpPost]
+        public async Task<IActionResult> CreateUserAsync([FromBody] CreateUserDto dto)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            // Generoidaan 8-merkkinen kertakäyttökoodi
+            var oneTimeCode = Guid.NewGuid().ToString("N").Substring(0, 8);
+
+            var user = new UserModel
+            {
+                Username = dto.Username,
+                Email = dto.Email,
+                OneTimeCode = oneTimeCode,
+                Role = UserRole.Student
+            };
+
+            _context.Users.Add(user);
+            await _context.SaveChangesAsync();
+
+            return Ok(new { user.Id, user.Username, user.Email, user.OneTimeCode });
+        }
+
+        /// <summary>
+        /// DTO luokka uuden käyttäjän luonnille
+        /// </summary>
+        public class CreateUserDto
+        {
+            public required string Username { get; set; }
+            public required string Email { get; set; }
+        }
+
+
         /// <summary>
         /// Dto luokka varauksen muokkaamiselle
         /// </summary>

--- a/gamelab/src/server/Migrations/20250331115548_AddOneTimeCodeToUser.Designer.cs
+++ b/gamelab/src/server/Migrations/20250331115548_AddOneTimeCodeToUser.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using gamelab.src.server;
@@ -11,9 +12,11 @@ using gamelab.src.server;
 namespace server.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250331115548_AddOneTimeCodeToUser")]
+    partial class AddOneTimeCodeToUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/gamelab/src/server/Migrations/20250331115548_AddOneTimeCodeToUser.cs
+++ b/gamelab/src/server/Migrations/20250331115548_AddOneTimeCodeToUser.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace server.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOneTimeCodeToUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "OneTimeCode",
+                table: "User",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "OneTimeCode",
+                table: "User");
+        }
+    }
+}

--- a/gamelab/src/server/Models/UserModel.cs
+++ b/gamelab/src/server/Models/UserModel.cs
@@ -24,6 +24,10 @@ namespace gamelab.src.server.Models
         [EmailAddress]
         public string? Email { get; set; }
 
+         // Uusi property kertakäyttökoodille
+        [Required]
+        public string OneTimeCode { get; set; } = "";
+
         public ICollection<Reservation>? Reservation { get; set; } //Navigointi ominaisuus, tämä ilmeisesti on hyvä olla
         
         [Required]

--- a/gamelab/src/server/appsettings.Development.json
+++ b/gamelab/src/server/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
     "ConnectionStrings": {
-      "DefaultConnection": "Server=localhost;Port=5432;Database=GameLab;Username=postgres;Password=password;"
+      "DefaultConnection": "Server=localhost;Port=5432;Database=GameLab;Username=postgres;Password=OikeaSalasana;"
     },
     "Logging": {
       "LogLevel": {

--- a/gamelab/src/server/appsettings.Development.json
+++ b/gamelab/src/server/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
     "ConnectionStrings": {
-      "DefaultConnection": "Server=localhost;Port=5432;Database=GameLab;Username=postgres;Password=OikeaSalasana;"
+      "DefaultConnection": "Server=localhost;Port=5432;Database=GameLab;Username=postgres;Password=password;"
     },
     "Logging": {
       "LogLevel": {

--- a/gamelab/src/server/appsettings.json
+++ b/gamelab/src/server/appsettings.json
@@ -1,6 +1,6 @@
 {
 "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost;Database=GameLab;Username=postgres;Password=0000;"
+    "DefaultConnection": "Server=localhost;Database=GameLab;Username=postgres;Password=OikeaSalasana;"
   },
 
   "Logging": {

--- a/gamelab/src/server/appsettings.json
+++ b/gamelab/src/server/appsettings.json
@@ -1,6 +1,6 @@
 {
 "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost;Database=GameLab;Username=postgres;Password=OikeaSalasana;"
+    "DefaultConnection": "Server=localhost;Database=GameLab;Username=postgres;Password=password;"
   },
 
   "Logging": {


### PR DESCRIPTION
Uuden käyttäjän luominen (POST)

Endpointin reittinä on api/user ja metodi vastaanottaa CreateUserDto-olion, jossa on kentät Username ja Email.

Kertakäyttökoodi generoidaan GUID:sta otetusta 8-merkkisestä osasta.

Uusi käyttäjä tallennetaan tietokantaan käyttämällä Entity Framework Corea.

Palautetaan onnistuneesti luodun käyttäjän tiedot (mukaan lukien generoitu kertakäyttökoodi).

Hyväksymiskriteerit

Uuden käyttäjän sähköposti tallennetaan tietokantaan: Käyttäjän sähköposti tallennetaan UserModeliin, joka vastaa tietokantataulua "User".

Sähköpostille linkitetään kertakäyttökoodi: Luomisen yhteydessä generoidaan kertakäyttökoodi, joka tallennetaan OneTimeCode-kenttään.

Käyttäjän tiedot on tallennettu tietokantaan oikeaan tauluun: Käyttäjä tallennetaan _context.Users-addition kautta ja tallennetaan tietokantaan.